### PR TITLE
Change the default config file to .jscsrc and bump version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To install via Package Control, do the following:
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings](http://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html).
 
-Since this plugin is executing `jscs` on your system, you may use `.jscs.json` files to configure its behavior. See the [jscs documentation](https://github.com/mdevils/node-jscs#configuration) for more information.
+Since this plugin is executing `jscs` on your system, you may use `.jscsrc` files to configure its behavior. See the [jscs documentation](https://github.com/mdevils/node-jscs#configuration) for more information.
 
-**Note**: Whereas `jscs` only looks in the linted file’s directory for a `.jscs.json` file, this linter plugin extends that behavior by searching the file hierarchy up to the root directory and then in the user’s home directory.
+**Note**: Whereas `jscs` only looks in the linted file’s directory for a `.jscsrc` file, this linter plugin extends that behavior by searching the file hierarchy up to the root directory and then in the user’s home directory.
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -32,4 +32,4 @@ class Jscs(Linter):
     multiline = True
     selectors = {'html': 'source.js.embedded.html'}
     tempfile_suffix = 'js'
-    config_file = ('--config', '.jscs.json', '~')
+    config_file = ('--config', '.jscsrc', '~')

--- a/messages.json
+++ b/messages.json
@@ -1,4 +1,5 @@
 {
     "install": "messages/install.txt",
-    "1.0.2": "messages/1.0.2.txt"
+    "1.0.2": "messages/1.0.2.txt",
+    "2.0.0": "messages/2.0.0.txt"
 }

--- a/messages/2.0.0.txt
+++ b/messages/2.0.0.txt
@@ -1,0 +1,5 @@
+SublimeLinter-jscs 2.0.0
+-------------------------
+The default configuration file for `jscs` is now
+`.jscsrc` instead of `.jscs.json`. Please consider
+renaming this file.


### PR DESCRIPTION
Hi, please consider this change and releasing a new version. As a maintainer of `jscs`, we'd like to promote everyone changing to `.jscsrc` and not have new users of `SublimeLinter` be forced to change the package configuration.

Thanks!
