### PR TITLE
Updated linter.py to use new inlinesingle reporter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,7 +10,7 @@
 
 """This module exports the jscs plugin class."""
 
-from SublimeLinter.lint import Linter
+from SublimeLinter.lint import Linter, util
 
 
 class Jscs(Linter):
@@ -18,18 +18,16 @@ class Jscs(Linter):
     """Provides an interface to jscs."""
 
     syntax = ('javascript', 'html')
-    cmd = 'jscs -r checkstyle'
+    cmd = 'jscs -r inlinesingle'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 1.0.10'  # 1.0.10 introduced checkstyle reporter
-    regex = (
-        r'^\s+?<error line="(?P<line>\d+)" '
-        r'column="(?P<col>\d+)" '
-        # jscs always reports with error severity; show as warning
-        r'severity="(?P<warning>error)" '
-        r'message="(?P<message>.+?)"'
-    )
-    multiline = True
+    version_requirement = '>= 1.4.0'  # 1.4.0 introduced inlinesingle reporter
+    regex = r'''(?xi)
+        ^.+:\s* # filename
+        (?:line.(?P<line>\d+),.col.(?P<col>\d+),.)
+        (?P<message>.*)
+    '''
+    error_stream = util.STREAM_STDOUT
     selectors = {'html': 'source.js.embedded.html'}
     tempfile_suffix = 'js'
     config_file = ('--config', '.jscsrc', '~')


### PR DESCRIPTION
[Several of us](https://github.com/SublimeLinter/SublimeLinter-jscs/issues/6) have been having problems with node-jscs working properly with SublimeLinter-jscs on Windows7+ machines. It appears this is due to SublimeText not managing multi-line output properly on these machines.

To fix this [I've created a new node-jscs inline reporter called inlinesingle](https://github.com/mdevils/node-jscs/pull/348) which SublimeLinter-jscs can use instead.

The new reporter was added to node-jscs in v1.4.0.

I should point out that I've only tested this on Windows 7. It will require testing on Mac/Linux but I can't forsee any issues.
