### PR TITLE
pass data via stdin to support 1.5.9+

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,7 @@ class Jscs(Linter):
     cmd = 'jscs -r checkstyle'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 1.0.10'  # 1.0.10 introduced checkstyle reporter
+    version_requirement = '>= 1.5.9'  # 1.5.9 introduced reading from stdin
     regex = (
         r'^\s+?<error line="(?P<line>\d+)" '
         r'column="(?P<col>\d+)" '
@@ -31,5 +31,4 @@ class Jscs(Linter):
     )
     multiline = True
     selectors = {'html': 'source.js.embedded.html'}
-    tempfile_suffix = 'js'
     config_file = ('--config', '.jscsrc', '~')


### PR DESCRIPTION
JSCS v1.5.9 introduced support for reading via stdin. Unfortunately, its
detection logic is primitive and if stdin is not a TTY (as in
SublimeLinter's case), it will _always_ attempt to read from stdin, even
if a filename was passed.

As a workaround, just pass the file via stdin and require JSCS 1.5.9+.
This strategy should be compatible with all future versions.
