### PR TITLE
Update docs to reflect current `jscs` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ To install via Package Control, do the following:
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings](http://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html).
 
-Since this plugin is executing `jscs` on your system, you may use `.jscsrc` files to configure its behavior. See the [jscs documentation](https://github.com/mdevils/node-jscs#configuration) for more information.
-
-**Note**: Whereas `jscs` only looks in the linted file’s directory for a `.jscsrc` file, this linter plugin extends that behavior by searching the file hierarchy up to the root directory and then in the user’s home directory.
+Since this plugin is executing `jscs` on your system, you may use `.jscsrc` files to configure its behavior. See the [jscs documentation](https://github.com/jscs-dev/node-jscs#cli) for more information.
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:


### PR DESCRIPTION
- `jscs` now supports the folders search up to the root and user's `home` directory.
- `#configuration` no longer exists in `jscs` docs